### PR TITLE
timeout: initialize env and process input before timeout closure

### DIFF
--- a/src/com/daimler/pipeliner/BasePipeline.groovy
+++ b/src/com/daimler/pipeliner/BasePipeline.groovy
@@ -716,6 +716,8 @@ abstract class BasePipeline implements Serializable {
      * @return A Map of the input-output parameters passed to and modified by this pipeline
      */
     Map run() {
+        initializeFromEnvironment()
+        processUserInput()
         this.script.timeout(time: this.pipelineTimeout, unit: 'MINUTES'){
             this.script.timestamps {
                return runInternal()
@@ -733,9 +735,6 @@ abstract class BasePipeline implements Serializable {
         Map joblist = [:]
         //List for parallels for this pipeline
         def parallelList = []
-
-        initializeFromEnvironment()
-        processUserInput()
 
         def stageInputs = getStageInputs()
         stageInputs.eachWithIndex {

--- a/src/com/daimler/pipeliner/BasePipeline.groovy
+++ b/src/com/daimler/pipeliner/BasePipeline.groovy
@@ -34,6 +34,11 @@ abstract class BasePipeline implements Serializable {
      */
     protected String nodeLabelExpr = ''
     /**
+     * The timeout for pipeline in Minutes
+     * Default value 210 minutes = 3.5 hours
+     */
+    protected Integer pipelineTimeout = 210
+    /**
      * The docker container which from private registry should be used to run this pipeline
      */
     protected String dockerImage = ''
@@ -711,8 +716,10 @@ abstract class BasePipeline implements Serializable {
      * @return A Map of the input-output parameters passed to and modified by this pipeline
      */
     Map run() {
-        this.script.timestamps {
-            return runInternal()
+        this.script.timeout(time: this.pipelineTimeout, unit: 'MINUTES'){
+            this.script.timestamps {
+               return runInternal()
+            }
         }
     }
 

--- a/src/com/daimler/pipeliner/BasePipeline.groovy
+++ b/src/com/daimler/pipeliner/BasePipeline.groovy
@@ -722,7 +722,6 @@ abstract class BasePipeline implements Serializable {
             this.script.timestamps {
                return runInternal()
             }
-            }
         }
     }
 


### PR DESCRIPTION
The initializeFromEnvironment() and processUserInput() has to be called before timeout closure so it can be processed as an input from user