### PR TITLE
Add hooking on functionality after docker image is built

### DIFF
--- a/src/com/daimler/pipeliner/BasePipeline.groovy
+++ b/src/com/daimler/pipeliner/BasePipeline.groovy
@@ -124,6 +124,11 @@ abstract class BasePipeline implements Serializable {
      */
     protected String currentGroupId
     /**
+     * Name of the docker image and tag used to build.
+     * Value is available once the docker image is built.
+     */
+    protected String dockerImageTag = ''
+    /**
      * Root user constant that is used to run docker
      */
     final String DOCKER_ROOT_USER = "-u 0:0"
@@ -607,6 +612,8 @@ abstract class BasePipeline implements Serializable {
         if (!this.dockerArgs.contains(DOCKER_ROOT_USER)) {
             tag = appendCurrentUserToImage(image, userId, groupId, currentUser)
         }
+
+        this.dockerImageTag = tag
 
         checkDockerVolumeDirectories(evaluatedArgs)
 

--- a/src/com/daimler/pipeliner/BasePipeline.groovy
+++ b/src/com/daimler/pipeliner/BasePipeline.groovy
@@ -238,6 +238,18 @@ abstract class BasePipeline implements Serializable {
      */
     abstract void stages(Map stageInput)
 
+    /**
+     * Post function hook that is executed after the docker image is built.
+     *
+     * NOTE: This is run inside of the scheduled node and workspace
+     * NOTE: This is run for each parallel separately
+     *
+     * @param A Map with the inputs for stages
+     */
+    void postDockerBuild(Map stageInput) {
+        Logger.info("BasePipeline: postDockerBuild")
+    }
+
    /**
      * Post function hook that is executed after the build exits docker container
      * but before the image is removed.
@@ -627,6 +639,8 @@ abstract class BasePipeline implements Serializable {
         }
 
         this.dockerImageTag = tag
+
+        this.postDockerBuild(stageInput)
 
         checkDockerVolumeDirectories(evaluatedArgs)
 

--- a/src/com/daimler/pipeliner/BasePipeline.groovy
+++ b/src/com/daimler/pipeliner/BasePipeline.groovy
@@ -238,6 +238,19 @@ abstract class BasePipeline implements Serializable {
      */
     abstract void stages(Map stageInput)
 
+   /**
+     * Post function hook that is executed after the build exits docker container
+     * but before the image is removed.
+     *
+     * NOTE: This is run inside of the scheduled node and workspace
+     * NOTE: This is run for each parallel separately
+     *
+     * @param A Map with the inputs for stages
+     */
+    void postDocker(Map stageInput) {
+        Logger.info("BasePipeline: postDocker")
+    }
+
     /**
      * Post function hook that is executed even in case earlier stages have failed
      *
@@ -647,6 +660,8 @@ abstract class BasePipeline implements Serializable {
                 }
             }
         }, this.checkoutCredentialsId)
+
+        this.postDocker(stageInput)
 
         //Remove custom current user layers
         if (!this.dockerArgs.contains(DOCKER_ROOT_USER) && utils.shWithStatus("docker rmi " + tag) != 0) {


### PR DESCRIPTION
This functionality enables post-build actions for docker image building.
Post-build actions are called after docker image is built and after the build exits docker.

Sofiia Kalinina <sofiia.kalinina@daimler.com> Daimler AG on behalf of MBition GmbH

https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md