### PR TITLE
fix recursive submodule checkout

### DIFF
--- a/src/com/daimler/pipeliner/ScriptUtils.groovy
+++ b/src/com/daimler/pipeliner/ScriptUtils.groovy
@@ -399,7 +399,7 @@ public class ScriptUtils {
 
         def cmd = 'git submodule update --init'
         if (args != null)
-            cmd += args.join(" ")
+            cmd += ' ' + args.join(" ")
         else
             cmd += "\n"
 


### PR DESCRIPTION
args for checkout were not working,
because of missing whitesapce after
'--init' and the args

fixed now