### PR TITLE
Docker: Cleanup builder caches on every run

### DIFF
--- a/src/com/daimler/pipeliner/BasePipeline.groovy
+++ b/src/com/daimler/pipeliner/BasePipeline.groovy
@@ -593,6 +593,16 @@ abstract class BasePipeline implements Serializable {
     }
 
     /**
+     * Function to prune docker builder caches
+     *
+     * Since we're using DOCKER_BUILDKIT and it has some issues in handling caches
+     * for pulled images, we need to manually cleanup builder caches
+     */
+    void dockerPrune() {
+        script.sh "docker builder prune -af"
+    }
+
+    /**
      * Function to run docker stages inside already specified node and workspace
      *
      * @param A Map with the inputs for stages
@@ -614,6 +624,8 @@ abstract class BasePipeline implements Serializable {
         //Tag that we use for building and running a container
         String tag = this.dockerImage
         String customTag = null
+
+        dockerPrune()
 
         //Check if we need to use a custom image, if so, build a new image with it
         if (this.customDockerfileSource) {


### PR DESCRIPTION
Since we're using DOCKER_BUILDKIT and it has some issues in handling
caches for pulled images, we need to make sure that builder caches
are not causing problems.

It's fairly safe to prune builder caches as it does not affect already
running builds and it does not remove images/containers.

Sofiia Kalinina sofiia.kalinina@daimler.com Daimler AG on behalf of MBition GmbH

https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md